### PR TITLE
add external tutorial on using DL features

### DIFF
--- a/docs/source/references.rst
+++ b/docs/source/references.rst
@@ -32,3 +32,8 @@ References
     Aric A. Hagberg, Daniel A. Schult and Pieter J. Swart, |br|
     *Exploring Network Structure, Dynamics, and Function using NetworkX*, |br|
     `SciPyProceedings_11 2008 <http://conference.scipy.org/proceedings/SciPy2008/paper_2/>`__.
+
+.. [ResNet16]
+    K. He, X. Zhang, S. Ren and J. Sun, |br|
+    *Deep Residual Learning for Image Recognition*, |br|
+    `2016 IEEE Conference on Computer Vision and Pattern Recognition (CVPR), Las Vegas, NV, 2016, pp. 770-778, <https://ieeexplore.ieee.org/document/7780459>`_.

--- a/tutorials/external_tutorial_DL_features.py
+++ b/tutorials/external_tutorial_DL_features.py
@@ -22,14 +22,12 @@ These DL-powered features can be very powerful and provide a semantically meanin
 
 Here, we show how to use the feature extraction pipeline defined in :mod:`squidpy.im` to extract features from
 a pretrained neural network.
-For this, we use a ResNet50 with weights pretrained on `ImageNet`_.
+For this, we use a ResNet50 ([ResNet16]_) with weights pretrained on `ImageNet`_.
 
 To execute this notebook, you need to install ``tensorflow`` in addition to ``squidpy``.
 TODO more info on how to install
 
 .. _ImageNet: http://www.image-net.org
-
-Citation: Deep Residual Learning for Image Recognition (CVPR 2015) https://arxiv.org/abs/1512.03385
 """
 
 import time


### PR DESCRIPTION
external image tutorial that require additional packages (ie tensor flow) and should not be executed in CI.
This tutorial shows how to use DL-based features.

Might need to be moved to other folder. Also, format might change (upload .ipynb?)