### PR TITLE
fix instruction to install locally with conda

### DIFF
--- a/docs/source/auto_tutorials/tutorial_imc.rst
+++ b/docs/source/auto_tutorials/tutorial_imc.rst
@@ -33,7 +33,7 @@ For details on how it was pre-processed, please refer to the original paper.
 
 Import packages & data
 ----------------------
-To run the notebook locally, create a conda environment as *conda create -f environment.yml* using this
+To run the notebook locally, create a conda environment as *conda env create -f environment.yml* using this
 `environment.yml <https://github.com/theislab/squidpy_notebooks/blob/master/environment.yml>`_
 
 .. GENERATED FROM PYTHON SOURCE LINES 21-31


### PR DESCRIPTION
Original instruction to create conda environment gives error, because it is missing the "env" argument after conda.
See https://stackoverflow.com/questions/56871882/condavalueerror-the-target-prefix-is-the-base-prefix-aborting