### PR TITLE
Fix spellcheck and enable linkcheck

### DIFF
--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -48,7 +48,6 @@
 	doi = {10.1101/2020.08.29.272831},
 	publisher = {Cold Spring Harbor Laboratory},
 	URL = {https://www.biorxiv.org/content/early/2020/09/24/2020.08.29.272831},
-	eprint = {https://www.biorxiv.org/content/early/2020/09/24/2020.08.29.272831.full.pdf},
 	journal = {bioRxiv}
 }
 
@@ -90,6 +89,5 @@
 	doi = {10.1101/2020.07.24.219758},
 	publisher = {Cold Spring Harbor Laboratory},
 	URL = {https://www.biorxiv.org/content/early/2020/07/25/2020.07.24.219758},
-	eprint = {https://www.biorxiv.org/content/early/2020/07/25/2020.07.24.219758.full.pdf},
 	journal = {bioRxiv}
 }

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -42,3 +42,16 @@ Tensorflow
 ligand
 uncommenting
 segmentations
+# CI
+ligands
+tori
+autocorrelation
+datasets
+parallelization
+interpretable
+CP
+Dentate
+gyrus
+Tangram
+sc
+centroids

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -54,4 +54,5 @@ Dentate
 gyrus
 Tangram
 sc
+centroid
 centroids

--- a/examples/image/compute_custom_features.py
+++ b/examples/image/compute_custom_features.py
@@ -56,7 +56,7 @@ adata.obsm["custom_features"].head()
 
 ###############################################################################
 # Use :func:`squidpy.pl.extract` to plot the histogram features on the tissue image or have a look at
-# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.html>`_ to learn
+# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.ipynb>`_ to learn
 # how to use our interactive :mod:`napari` plugin.
 
 sc.pl.spatial(

--- a/examples/image/compute_histogram_features.py
+++ b/examples/image/compute_histogram_features.py
@@ -47,7 +47,7 @@ adata.obsm["histogram_features"].head()
 
 ###############################################################################
 # Use :func:`squidpy.pl.extract` to plot the histogram features on the tissue image or have a look at
-# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.html>`_ to
+# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.ipynb>`_ to
 # learn how to use our interactive :mod:`napari` plugin.
 # With these features we can e.g. appreciate the detailed distribution of
 # intensity values of channel 0 (DAPI stain) on the different bins.

--- a/examples/image/compute_segmentation_features.py
+++ b/examples/image/compute_segmentation_features.py
@@ -73,7 +73,7 @@ adata.obsm["segmentation_features"].head()
 
 ###############################################################################
 # Use :func:`squidpy.pl.extract` to plot the texture features on the tissue image or have a look at
-# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.html>`_ to learn
+# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.ipynb>`_ to learn
 # how to use our interactive :mod:`napari` plugin.
 # Here, we show all calculated segmentation features.
 

--- a/examples/image/compute_summary_features.py
+++ b/examples/image/compute_summary_features.py
@@ -60,7 +60,7 @@ adata.obsm["summary_features"].head()
 
 ###############################################################################
 # Use :func:`squidpy.pl.extract` to plot the summary features on the tissue image or have a look at
-# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.html>`_ to learn
+# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.ipynb>`_ to learn
 # how to use our interactive :mod:`napari` plugin.
 # Note how the spatial distribution of channel means is different for fluorescence channels 0 (DAPI stain)
 # and 1 (GFAP stain).

--- a/examples/image/compute_texture_features.py
+++ b/examples/image/compute_texture_features.py
@@ -55,7 +55,7 @@ adata.obsm["texture_features"].head()
 
 ###############################################################################
 # Use :func:`squidpy.pl.extract` to plot the texture features on the tissue image or have a look at
-# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.html>`_ to learn
+# `our interactive visualisation tutorial <../../external_tutorials/tutorial_napari.ipynb>`_ to learn
 # how to use our interactive :mod:`napari` plugin.
 # Here, we show the contrast feature for channels 0 and 1.
 # The two stains, DAPI in channel 0, and GFAP in channel 1 show different regions of high contrast.

--- a/tox.ini
+++ b/tox.ini
@@ -74,9 +74,8 @@ deps = -r{toxinidir}/docs/requirements.txt
 skip_install = true
 whitelist_externals = sphinx-build
 commands =
-    sphinx-build -D plot_gallery=0 -b spelling {toxinidir}/docs/source {toxinidir}/docs/build/spellcheck
-    # TODO: uncomment me once the links are set-up correctly
-    # sphinx-build -q -W --keep-going -D plot_gallery=0 -b linkcheck {toxinidir}/docs/source {toxinidir}/docs/build/linkcheck
+    sphinx-build -W --keep-going -D plot_gallery=0 -b spelling {toxinidir}/docs/source {toxinidir}/docs/build/spellcheck
+    sphinx-build -q -W --keep-going -D plot_gallery=0 -b linkcheck {toxinidir}/docs/source {toxinidir}/docs/build/linkcheck
 
 [testenv:docs]
 description = Build the documentation.


### PR DESCRIPTION
Note for future: remove `eprint` from `bibtex` if present (it prefixes the links wih `https://arxiv.org/...`).